### PR TITLE
Refacto/hompage api/presentation section

### DIFF
--- a/src/api/apiRoutes.jsx
+++ b/src/api/apiRoutes.jsx
@@ -20,4 +20,7 @@ export const API_ROUTES = {
   CARD: {
     BY_USER: (userId) => `${API_BASE}/card?user_id=${userId}`,
   },
+  CAROUSEL: {
+    GET: `http://localhost:8082/api/v1/carousel`,
+  },
 };

--- a/src/components/Home/CarouselContainer.jsx
+++ b/src/components/Home/CarouselContainer.jsx
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { API_ROUTES } from "../../api/apiRoutes";
+import Carousel from "./Carousel";
+
+const CarouselContainer = () => {
+  const [slides, setSlides] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSlides = async () => {
+      try {
+        const response = await axios.get(API_ROUTES.CAROUSEL.GET);
+
+        const formattedSlides = response.data.map((item, index) => ({
+          id: item.id,
+          imageUrl: item.imageUrl, // fallback temporaire
+          title: item.title,
+          description: item.text,
+          ctaText: item.ctaText || "Voir nos produits",
+          ctaLink: item.ctaLink || "/categories",
+        }));
+
+        setSlides(formattedSlides);
+      } catch (err) {
+        console.error("Erreur récupération carrousel :", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSlides();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="w-full flex justify-center items-center h-96">
+        <p className="text-gray-600 text-lg">Chargement du carrousel...</p>
+      </div>
+    );
+  }
+
+  return <Carousel slides={slides} delayTransitionImage={5000} />;
+};
+
+export default CarouselContainer;

--- a/src/components/Home/CarouselContainer.jsx
+++ b/src/components/Home/CarouselContainer.jsx
@@ -14,7 +14,7 @@ const CarouselContainer = () => {
 
         const formattedSlides = response.data.map((item, index) => ({
           id: item.id,
-          imageUrl: item.imageUrl, // fallback temporaire
+          imageUrl: item.imageUrl,
           title: item.title,
           description: item.text,
           ctaText: item.ctaText || "Voir nos produits",

--- a/src/components/Home/HeroSection.jsx
+++ b/src/components/Home/HeroSection.jsx
@@ -1,4 +1,4 @@
-import Carousel from "./Carousel";
+import CarouselContainer from "./CarouselContainer";
 
 const HeroSection = () => {
   return (
@@ -7,7 +7,7 @@ const HeroSection = () => {
       className="w-full flex flex-col items-center justify-center   p-10"
     >
       <div className="w-full flex flex-col items-center justify-center bg-primaryBackground rounded-md overflow-hidden">
-        <Carousel />
+        <CarouselContainer />
       </div>
     </section>
   );

--- a/src/components/Home/PresentationSection.jsx
+++ b/src/components/Home/PresentationSection.jsx
@@ -1,16 +1,38 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { API_ROUTES } from "../../api/apiRoutes";
 import CTAButton from "../ui/buttons/CTAButton";
 
 const PresentationSection = () => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    const fetchPresentation = async () => {
+      try {
+        const response = await axios.get(API_ROUTES.CAROUSEL.GET);
+        const firstSlide = response.data[0];
+        setTitle(firstSlide.title);
+        setDescription(firstSlide.text);
+      } catch (err) {
+        console.error("Erreur lors du chargement de la présentation :", err);
+        setTitle("Pure player en cybersécurité pour PME et MSP");
+        setDescription(
+          "Cyna est spécialisée dans la vente de solutions de sécurité SaaS innovantes telles que SOC, EDR et XDR. Notre plateforme e-commerce internationale permet aux entreprises d’accéder à des services de protection avancée."
+        );
+      }
+    };
+
+    fetchPresentation();
+  }, []);
+
   return (
     <section className="w-full bg-gray-100 py-10 px-6 rounded-lg md:px-20 text-center ">
       <h1 className="text-3xl md:text-4xl font-extrabold text-primaryBackground">
-        Pure player en cybersécurité pour PME et MSP
+        {title}
       </h1>
       <p className="mt-4 text-gray-700 text-lg md:text-xl max-w-3xl mx-auto">
-        Cyna est spécialisée dans la vente de solutions de sécurité SaaS
-        innovantes telles que SOC, EDR et XDR. Notre plateforme e-commerce
-        internationale permet aux entreprises d’accéder à des services de
-        protection avancée.
+        {description}
       </p>
       <div
         id="containerCTA"


### PR DESCRIPTION
feat(homepage): détournement temporaire de /carousel pour alimenter PresentationSection

La route GET /api/v1/carousel est utilisée provisoirement pour afficher le bloc de présentation sous le carrousel (texte d’intro + titre).  
En attente d’un endpoint dédié type /presentation ou /homepage-text côté backend.

Composant concerné : PresentationSection.jsx
Prochaine étape : bascule vers l'endpoint final dès qu’il est disponible.

