### PR TITLE
Refacto/hompage api/presentation section

### DIFF
--- a/src/api/apiRoutes.jsx
+++ b/src/api/apiRoutes.jsx
@@ -20,7 +20,12 @@ export const API_ROUTES = {
   CARD: {
     BY_USER: (userId) => `${API_BASE}/card?user_id=${userId}`,
   },
+
+  /* HOMEPAGE */
   CAROUSEL: {
     GET: `http://localhost:8082/api/v1/carousel`,
+  },
+  CATEGORIES: {
+    GET: `http://localhost:8082/api/v1/categories`,
   },
 };

--- a/src/api/apiRoutes.jsx
+++ b/src/api/apiRoutes.jsx
@@ -28,4 +28,7 @@ export const API_ROUTES = {
   CATEGORIES: {
     GET: `http://localhost:8082/api/v1/categories`,
   },
+  PRODUCTS: {
+    TOP_PRODUCTS: `http://localhost:8082/api/v1/products/top-products`,
+  },
 };

--- a/src/components/Home/CategoriesGrid.jsx
+++ b/src/components/Home/CategoriesGrid.jsx
@@ -1,7 +1,39 @@
+import axios from "axios";
+import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+import { API_ROUTES } from "../../api/apiRoutes";
 import { MOCK_Categories } from "../../mock/MOCKS_DATA";
 import CategoryCard from "./CategoryCard";
 
 const CategoriesGrid = () => {
+  const [categories, setCategories] = useState([]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const response = await axios.get(API_ROUTES.CATEGORIES.GET);
+
+        const mappedCategories = response.data.map((cat) => ({
+          id: cat.id,
+          name: cat.name,
+          imageUrl:
+            cat.images?.[0]?.url || "/assets/images/placeholder-category.jpg", // fallback image
+          url: cat.id.toString(), // route param
+        }));
+
+        setCategories(mappedCategories);
+      } catch (error) {
+        console.warn(
+          "Échec de récupération des catégories, fallback mock :",
+          error
+        );
+        setCategories(MOCK_Categories);
+      }
+    };
+
+    fetchCategories();
+  }, []);
+
   return (
     <section className="w-full py-10 px-6 md:px-20">
       <h2 className="text-2xl md:text-3xl font-bold text-center text-primaryBackground">
@@ -11,9 +43,9 @@ const CategoriesGrid = () => {
         Découvrez nos différentes solutions de cybersécurité adaptées à vos
         besoins.
       </p>
-      {/* Passer en 3 cols contre 4 car pb de rendu => moche et que 3 catégories pour le moment */}
+
       <div className="mt-6 grid grid-cols-2 md:grid-cols-3 gap-6">
-        {MOCK_Categories.map((category) => (
+        {categories.map((category) => (
           <CategoryCard key={category.id} category={category} />
         ))}
       </div>
@@ -22,3 +54,12 @@ const CategoriesGrid = () => {
 };
 
 export default CategoriesGrid;
+
+CategoryCard.propTypes = {
+  category: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    name: PropTypes.string.isRequired,
+    imageUrl: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -1,13 +1,13 @@
 import CategoriesGrid from "./CategoriesGrid";
 import HeroSection from "./HeroSection";
-import PresentationSection from "./PresentationSection";
+import PromoSection from "./PromoSection";
 import TopProductsGrid from "./TopProductsGrid";
 
 const Home = () => {
   return (
     <div id="homepageContent" className="max-w-6xl mx-auto my-4 px-4">
       <HeroSection />
-      <PresentationSection />
+      <PromoSection />
       <CategoriesGrid />
       <TopProductsGrid />
     </div>

--- a/src/components/Home/PromoSection.jsx
+++ b/src/components/Home/PromoSection.jsx
@@ -1,48 +1,38 @@
 import axios from "axios";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { API_ROUTES } from "../../api/apiRoutes";
 import CTAButton from "../ui/buttons/CTAButton";
 
 const PromoSection = () => {
-  const [slides, setSlides] = useState([]);
-  const [current, setCurrent] = useState(0);
-  const intervalRef = useRef(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
 
   useEffect(() => {
     const fetchPresentation = async () => {
       try {
         const response = await axios.get(API_ROUTES.CAROUSEL.GET);
-        setSlides(response.data);
-      } catch {
-        setSlides([
-          {
-            title: "Pure player en cybersécurité pour PME et MSP",
-            text: "Cyna est spécialisée dans la vente de solutions de sécurité SaaS innovantes telles que SOC, EDR et XDR. Notre plateforme e-commerce internationale permet aux entreprises d’accéder à des services de protection avancée.",
-          },
-        ]);
+        const firstSlide = response.data[0];
+        setTitle(firstSlide.title);
+        setDescription(firstSlide.text);
+      } catch (err) {
+        console.error("Erreur lors du chargement de la présentation :", err);
+        setTitle("Pure player en cybersécurité pour PME et MSP");
+        setDescription(
+          "Cyna est spécialisée dans la vente de solutions de sécurité SaaS innovantes telles que SOC, EDR et XDR. Notre plateforme e-commerce internationale permet aux entreprises d’accéder à des services de protection avancée."
+        );
       }
     };
 
     fetchPresentation();
   }, []);
 
-  useEffect(() => {
-    if (slides.length === 0) return;
-    intervalRef.current = setInterval(() => {
-      setCurrent((prev) => (prev + 1) % slides.length);
-    }, 15000);
-    return () => clearInterval(intervalRef.current);
-  }, [slides]);
-
-  const currentSlide = slides[current] || { title: "", text: "" };
-
   return (
     <section className="w-full bg-gray-100 py-10 px-6 rounded-lg md:px-20 text-center ">
       <h1 className="text-3xl md:text-4xl font-extrabold text-primaryBackground">
-        {currentSlide.title}
+        {title}
       </h1>
       <p className="mt-4 text-gray-700 text-lg md:text-xl max-w-3xl mx-auto">
-        {currentSlide.text}
+        {description}
       </p>
       <div
         id="containerCTA"
@@ -57,18 +47,6 @@ const PromoSection = () => {
           label="Contacter un expert"
         />
       </div>
-      {slides.length > 1 && (
-        <div className="flex justify-center mt-4 gap-2">
-          {slides.map((_, idx) => (
-            <span
-              key={idx}
-              className={`w-3 h-3 rounded-full ${
-                idx === current ? "bg-primaryBackground" : "bg-gray-400"
-              } inline-block`}
-            />
-          ))}
-        </div>
-      )}
     </section>
   );
 };

--- a/src/components/Home/PromoSection.jsx
+++ b/src/components/Home/PromoSection.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { API_ROUTES } from "../../api/apiRoutes";
 import CTAButton from "../ui/buttons/CTAButton";
 
-const PresentationSection = () => {
+const PromoSection = () => {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
 
@@ -51,4 +51,4 @@ const PresentationSection = () => {
   );
 };
 
-export default PresentationSection;
+export default PromoSection;

--- a/src/components/Home/PromoSection.jsx
+++ b/src/components/Home/PromoSection.jsx
@@ -1,38 +1,48 @@
 import axios from "axios";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { API_ROUTES } from "../../api/apiRoutes";
 import CTAButton from "../ui/buttons/CTAButton";
 
 const PromoSection = () => {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const [slides, setSlides] = useState([]);
+  const [current, setCurrent] = useState(0);
+  const intervalRef = useRef(null);
 
   useEffect(() => {
     const fetchPresentation = async () => {
       try {
         const response = await axios.get(API_ROUTES.CAROUSEL.GET);
-        const firstSlide = response.data[0];
-        setTitle(firstSlide.title);
-        setDescription(firstSlide.text);
-      } catch (err) {
-        console.error("Erreur lors du chargement de la présentation :", err);
-        setTitle("Pure player en cybersécurité pour PME et MSP");
-        setDescription(
-          "Cyna est spécialisée dans la vente de solutions de sécurité SaaS innovantes telles que SOC, EDR et XDR. Notre plateforme e-commerce internationale permet aux entreprises d’accéder à des services de protection avancée."
-        );
+        setSlides(response.data);
+      } catch {
+        setSlides([
+          {
+            title: "Pure player en cybersécurité pour PME et MSP",
+            text: "Cyna est spécialisée dans la vente de solutions de sécurité SaaS innovantes telles que SOC, EDR et XDR. Notre plateforme e-commerce internationale permet aux entreprises d’accéder à des services de protection avancée.",
+          },
+        ]);
       }
     };
 
     fetchPresentation();
   }, []);
 
+  useEffect(() => {
+    if (slides.length === 0) return;
+    intervalRef.current = setInterval(() => {
+      setCurrent((prev) => (prev + 1) % slides.length);
+    }, 15000);
+    return () => clearInterval(intervalRef.current);
+  }, [slides]);
+
+  const currentSlide = slides[current] || { title: "", text: "" };
+
   return (
     <section className="w-full bg-gray-100 py-10 px-6 rounded-lg md:px-20 text-center ">
       <h1 className="text-3xl md:text-4xl font-extrabold text-primaryBackground">
-        {title}
+        {currentSlide.title}
       </h1>
       <p className="mt-4 text-gray-700 text-lg md:text-xl max-w-3xl mx-auto">
-        {description}
+        {currentSlide.text}
       </p>
       <div
         id="containerCTA"
@@ -47,6 +57,18 @@ const PromoSection = () => {
           label="Contacter un expert"
         />
       </div>
+      {slides.length > 1 && (
+        <div className="flex justify-center mt-4 gap-2">
+          {slides.map((_, idx) => (
+            <span
+              key={idx}
+              className={`w-3 h-3 rounded-full ${
+                idx === current ? "bg-primaryBackground" : "bg-gray-400"
+              } inline-block`}
+            />
+          ))}
+        </div>
+      )}
     </section>
   );
 };

--- a/src/components/Home/TopProductsGrid.jsx
+++ b/src/components/Home/TopProductsGrid.jsx
@@ -1,7 +1,41 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { API_ROUTES } from "../../api/apiRoutes";
 import { MOCK_Services } from "../../mock/MOCKS_DATA";
 import ProductCard from "./ProductCard";
 
 const TopProductsGrid = () => {
+  const [topProducts, setTopProducts] = useState([]);
+
+  useEffect(() => {
+    const fetchTopProducts = async () => {
+      try {
+        const response = await axios.get(API_ROUTES.PRODUCTS.TOP_PRODUCTS);
+
+        const formattedProducts = response.data.map((product) => ({
+          id: product.id,
+          name: product.name,
+          imageUrl:
+            product.images?.[0] || "/assets/images/placeholder-product.jpg",
+          link: `/products/${product.id}`,
+        }));
+
+        setTopProducts(formattedProducts);
+      } catch (err) {
+        console.warn("Fallback mock pour les Top produits :", err);
+        const fallback = MOCK_Services.slice(0, 4).map((p) => ({
+          id: p.id,
+          name: p.name,
+          imageUrl: p.imageUrl,
+          link: `/products/${p.id}`,
+        }));
+        setTopProducts(fallback);
+      }
+    };
+
+    fetchTopProducts();
+  }, []);
+
   return (
     <section className="w-full py-10 px-6 rounded-lg md:px-20 bg-gray-100">
       <h2 className="text-2xl md:text-3xl font-bold text-center text-primaryBackground">
@@ -11,9 +45,8 @@ const TopProductsGrid = () => {
         Découvrez les solutions les plus demandées par nos clients.
       </p>
 
-      {/* Ajout d'un function random utile ou pas ? */}
       <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-6">
-        {MOCK_Services.slice(0, 4).map((product) => (
+        {topProducts.map((product) => (
           <ProductCard key={product.id} product={product} />
         ))}
       </div>


### PR DESCRIPTION
🔁 PR – Refacto de la page d’accueil en mode hybride (FE)
✅ Composants refactorés :
HeroSection → inchangé, toujours en attente de data enrichie côté back

PromoSection (ex-PresentationSection) : fetch depuis /api/v1/carousel, fallback prévu

CategoriesGrid : récupération dynamique via /api/v1/categories, avec fallback mock

TopProductsGrid : intégration dynamique via /api/v1/products/top-products?promo=true&active=true, fallback mock sur MOCK_Services

⚠️ Limitations en cours :
Stripe : bug bloquant lors de la création de produits → stripePrice invalide ou non reconnu, alors que le setup fonctionnait le week-end dernier (services OK + stripe listen actif)

📌 À prévoir :
Enrichir le payload carousel côté back pour HeroSection (images, CTA, liens)

Clarifier le modèle produit côté admin + Stripe (prix, statuts, FK catégorie)